### PR TITLE
Soong: Add curl and flock to allowed list

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -76,10 +76,12 @@ func GetConfig(name string) PathConfig {
 var Configuration = map[string]PathConfig{
 	"bash":    Allowed,
 	"cpio":    Allowed,
+	"curl":    Allowed,
 	"dd":      Allowed,
 	"diff":    Allowed,
 	"dlv":     Allowed,
 	"expr":    Allowed,
+	"flock":   Allowed,
 	"fuser":   Allowed,
 	"getopt":  Allowed,
 	"git":     Allowed,


### PR DESCRIPTION
*Fix spam for curl and flock used in wireguard to compile kernel

Change-Id: I8d03c78e5d0de32bfe4933386a9dce8bc6779122