### PR TITLE
allowlists: support inline signing for U

### DIFF
--- a/android/allowlists/allowlists.go
+++ b/android/allowlists/allowlists.go
@@ -66,6 +66,7 @@ var (
 		"build/bazel":                        Bp2BuildDefaultTrueRecursively,
 		"build/make/target/product/security": Bp2BuildDefaultTrue,
 		"build/make/tools":                   Bp2BuildDefaultTrue,
+		"vendor/sakura-priv":                 Bp2BuildDefaultTrue,
 		"build/make/tools/protos":            Bp2BuildDefaultTrue,
 		"build/make/tools/releasetools":      Bp2BuildDefaultTrue,
 		"build/make/tools/sbom":              Bp2BuildDefaultTrue,
@@ -541,7 +542,7 @@ var (
 		// Used for testing purposes only. Should not actually exist in the real source tree.
 		"testpkg/keep_build_file":/* recursive = */ false,
 
-		"vendor/lineage-priv/keys":/* recursive = */ false,
+		"vendor/sakura-priv":/* recursive = */ false,
 	}
 
 	Bp2buildModuleAlwaysConvertList = []string{


### PR DESCRIPTION
For those who have used .android-certs previously, cp .android-certs/* vendor/sakura-priv

Change-Id: I0464fefe11d299d02c94c0a6e5afecee03af05a7